### PR TITLE
Raise exception through breakpoints IO pipe

### DIFF
--- a/lib/fork_break/process.rb
+++ b/lib/fork_break/process.rb
@@ -19,7 +19,6 @@ module ForkBreak
           breakpoints << :forkbreak_end
         rescue StandardError => e
           breakpoints << e
-          raise
         ensure
           self.class.breakpoint_setter = nil
         end

--- a/lib/fork_break/process.rb
+++ b/lib/fork_break/process.rb
@@ -17,7 +17,7 @@ module ForkBreak
         begin
           returned_value = block.call(breakpoints)
           breakpoints << :forkbreak_end
-        rescue Exception => e
+        rescue StandardError => e
           breakpoints << e
           raise
         end
@@ -46,7 +46,7 @@ module ForkBreak
 
           if brk == @next_breakpoint
             return self
-          elsif brk.is_a?(Exception)
+          elsif brk.is_a?(StandardError)
             raise brk
           elsif brk == :forkbreak_end
             raise BreakpointNotReachedError, "Never reached breakpoint #{@next_breakpoint.inspect}"

--- a/lib/fork_break/process.rb
+++ b/lib/fork_break/process.rb
@@ -31,7 +31,11 @@ module ForkBreak
       @next_breakpoint = breakpoint
       @fork.execute unless @fork.pid
       puts "Parent is sending object #{breakpoint} to #{@fork.pid}" if @debug
-      @fork.send_object(breakpoint)
+      begin
+        @fork.send_object(breakpoint)
+      rescue Errno::EPIPE
+        # Already ended
+      end
       self
     end
 

--- a/lib/fork_break/process.rb
+++ b/lib/fork_break/process.rb
@@ -20,9 +20,10 @@ module ForkBreak
         rescue StandardError => e
           breakpoints << e
           raise
+        ensure
+          self.class.breakpoint_setter = nil
         end
 
-        self.class.breakpoint_setter = nil
         returned_value
       end
     end

--- a/spec/fork_break_spec.rb
+++ b/spec/fork_break_spec.rb
@@ -111,7 +111,49 @@ describe ForkBreak::Process do
     expect { process.finish.wait }.to raise_error(MyException)
   end
 
-  it 'raises a wait timeout eror when the process takes longer than the specified wait timeout' do
+  it 'raises process exception when waiting on breakpoints' do
+    class MyException < StandardError; end
+
+    class FileLock
+      include ForkBreak::Breakpoints
+
+      def initialize(path)
+        @file = File.open(path, File::RDWR | File::CREAT, 0600)
+      end
+
+      def set_once
+        breakpoints << :before_lock
+        @file.flock(File::LOCK_EX)
+        value = @file.read.to_i
+        breakpoints << :after_read
+        raise MyException if value > 0
+        @file.rewind
+        @file.write("1\n")
+        @file.flush
+        @file.truncate(@file.pos)
+      end
+    end
+
+    Dir.mktmpdir do |tmpdir|
+      lock_path = File.join(tmpdir, 'lock')
+
+      process_1, process_2 = 2.times.map do
+        ForkBreak::Process.new { FileLock.new(lock_path).set_once }
+      end
+
+      expect do
+        process_1.run_until(:after_read).wait
+        process_2.run_until(:before_lock).wait
+        process_2.run_until(:after_read) && sleep(0.1)
+        process_1.finish.wait
+        process_2.finish.wait
+      end.to raise_error(MyException)
+
+      File.unlink(lock_path)
+    end
+  end
+
+  it 'raises a wait timeout error when the process takes longer than the specified wait timeout' do
     process = ForkBreak::Process.new do
       sleep(1)
     end

--- a/spec/fork_break_spec.rb
+++ b/spec/fork_break_spec.rb
@@ -153,6 +153,26 @@ describe ForkBreak::Process do
     end
   end
 
+  it 'raises process exception quickly when waiting on breakpoints' do
+    class MyException < StandardError; end
+
+    class Raiser
+      include ForkBreak::Breakpoints
+
+      def run
+        raise MyException
+        breakpoints << :after_raise
+      end
+    end
+
+    process = ForkBreak::Process.new { Raiser.new.run }
+
+    expect do
+      process.run_until(:after_raise) && sleep(0.1)
+      process.finish.wait
+    end.to raise_error(MyException)
+  end
+
   it 'raises a wait timeout error when the process takes longer than the specified wait timeout' do
     process = ForkBreak::Process.new do
       sleep(1)


### PR DESCRIPTION
Re-use breakpoints pipe to send exceptions through to parent. Works around
issue with blocking on IO with no reader ready on the Fork ctrl pipe.